### PR TITLE
[BUGFIX] Ensure proper handling of null and invalid page metadata in HeaderDataService

### DIFF
--- a/Classes/Service/HeaderDataService.php
+++ b/Classes/Service/HeaderDataService.php
@@ -70,7 +70,7 @@ class HeaderDataService implements SingletonInterface
     /**
      * @var array|null
      */
-    protected ?array $currentPageMetaData;
+    protected ?array $currentPageMetaData = null;
 
     /**
      * @var string
@@ -102,10 +102,12 @@ class HeaderDataService implements SingletonInterface
 
         $page = $this->pageService->getCurrentPage();
 
-        $this->currentPageMetaData = $this->pageService->getPageMetaData(
-            $page['uid'],
-            $this->pageService->getCurrentSysLanguageUid()
-        );
+        if (is_array($page) && array_key_exists('uid', $page)) {
+            $this->currentPageMetaData = $this->pageService->getPageMetaData(
+                $page['uid'],
+                $this->pageService->getCurrentSysLanguageUid()
+            );
+        }
 
         $currentDomain = GeneralUtility::getIndpEnv('HTTP_HOST');
 
@@ -274,6 +276,9 @@ class HeaderDataService implements SingletonInterface
 
     protected function setRobotsMetaTag(): void
     {
+        if (!is_array($this->currentPageMetaData)) {
+            return;
+        }
         $noindexInherited = (bool) $this->currentPageMetaData['meta']['robots']['noindexInherited'];
         $nofollowInherited = (bool) $this->currentPageMetaData['meta']['robots']['nofollowInherited'];
 


### PR DESCRIPTION
If you are trying to view a record in a detail action or a page without translation in said foreign language,
the HeaderDataService will try to fetch the raw data by looking it up with the PageService using a Query Builder.

This will resolve in a null-result which will then cause multiple errors along the HeaderDataService.

This fixes the Bug, by checking things first, before using or passing the values